### PR TITLE
feat: add queue backpressure warning to concurrencyLimit (closes #22)

### DIFF
--- a/client/src/services/assessment/lib/concurrencyLimit.ts
+++ b/client/src/services/assessment/lib/concurrencyLimit.ts
@@ -3,6 +3,16 @@
  * Provides the same interface as p-limit but is CJS-compatible
  */
 
+/**
+ * Warning threshold for queue depth monitoring.
+ * If queue exceeds this size, a warning is emitted to help diagnose
+ * slow/stalled servers or runaway task accumulation.
+ *
+ * Set to 10000 to avoid false alarms on legitimate advanced security
+ * assessments which can queue ~3,475 tasks (29 tools × 20 patterns × 6 payloads).
+ */
+export const QUEUE_WARNING_THRESHOLD = 10000;
+
 export type LimitFunction = <T>(fn: () => Promise<T>) => Promise<T>;
 
 /**
@@ -56,6 +66,16 @@ export function createConcurrencyLimit(concurrency: number): LimitFunction {
         resolve: resolve as (value: unknown) => void,
         reject,
       });
+
+      // Emit warning if queue grows too large (potential slow/stalled server)
+      if (queue.length > QUEUE_WARNING_THRESHOLD) {
+        console.warn(
+          `[concurrencyLimit] Queue depth: ${queue.length} ` +
+            `(threshold: ${QUEUE_WARNING_THRESHOLD}). ` +
+            `This may indicate a slow/stalled server.`,
+        );
+      }
+
       next();
     });
   };


### PR DESCRIPTION
## Summary
- Add queue depth monitoring with warning threshold to `concurrencyLimit.ts`
- Emit warning when queue exceeds 10,000 pending tasks
- Add test coverage for warning behavior

## Context from Issue #22
Code review identified unbounded queue growth potential. This PR adds observability for detecting slow/stalled servers.

## Key Decision: Threshold of 10,000 (not 1,000)
The original proposal suggested `MAX_QUEUE_SIZE_WARNING = 1000`, but code review analysis found:
- Advanced security assessments queue ~3,475 tasks (29 tools × 20 patterns × 6 payloads)
- 1,000 would trigger false warnings on every legitimate advanced assessment
- 10,000 provides 188% headroom while still catching true runaway scenarios

## Test plan
- [x] Tests pass: `npm test -- concurrencyLimit`
- [x] New test: "should warn when queue exceeds threshold"
- [x] New test: "should not warn when queue is below threshold"

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)